### PR TITLE
Feature: initial setup

### DIFF
--- a/api/.env
+++ b/api/.env
@@ -16,7 +16,7 @@
 
 # API Platform distribution
 TRUSTED_PROXIES=127.0.0.1
-TRUSTED_HOSTS=^localhost|api.quotethiswoman.test$
+TRUSTED_HOSTS=^localhost|api.newsite.test$
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev

--- a/api/.env
+++ b/api/.env
@@ -16,7 +16,7 @@
 
 # API Platform distribution
 TRUSTED_PROXIES=127.0.0.1
-TRUSTED_HOSTS=^localhost$
+TRUSTED_HOSTS=^localhost|api.quotethiswoman.test$
 
 ###> symfony/framework-bundle ###
 APP_ENV=dev

--- a/api/.env.test
+++ b/api/.env.test
@@ -7,3 +7,6 @@ PANTHER_ERROR_SCREENSHOT_DIR=./var/error-screenshots
 
 # API Platform distribution
 TRUSTED_HOSTS=^example\.com|localhost$
+
+### Path to your local composer installation
+# COMPOSER_BINARY=

--- a/api/.gitignore
+++ b/api/.gitignore
@@ -18,4 +18,5 @@
 ###> symfony/phpunit-bridge ###
 .phpunit.result.cache
 /phpunit.xml
+/build/logs/phpunit
 ###< symfony/phpunit-bridge ###

--- a/api/README.md
+++ b/api/README.md
@@ -4,11 +4,11 @@ The API will be here.
 
 Refer to the [Getting Started Guide](https://api-platform.com/docs/distribution) for more information. If you'd like to not use Docker (hint: it's a _lot_ more work to do manual setup) then view [SETUP.md](SETUP.md).
 
-This starter template is the standard API Platform code (3.0.0) with some additional helpful things added:
+This starter template is the standard [API Platform](https://api-platform.com/) release [3.0.0](https://github.com/api-platform/api-platform/releases) with some additional helpful things added:
 
 * manual setup documentation
 * disabling Mercure
-* testing documentation
+* testing documentation (include code coverage)
 * php-cs-fixer integration
 
 ## Helpful development things

--- a/api/README.md
+++ b/api/README.md
@@ -29,6 +29,6 @@ composer run php-lint
 composer run php-cs-fixer
 ```
 
-The first command will show linting issues with files; the second will fix them. The former command also runs on PRs via a [Github workflow](vendor/api-platform/schema-generator/.github/workflows/ci.yml)
+The first command will show linting issues with files; the second will fix them. The former command also runs on PRs via a [Github workflow](../.github/workflows/ci.yml)
 
 If you're using VS Code then install the [junstyle.php-cs-fixer](https://marketplace.visualstudio.com/items?itemName=junstyle.php-cs-fixer) plugin. PHPStorm should integrate `php-cs-fixer` out of the box.

--- a/api/README.md
+++ b/api/README.md
@@ -1,4 +1,4 @@
-# Quote this Woman API
+# API Platform 3.x
 
 The API will be here.
 

--- a/api/README.md
+++ b/api/README.md
@@ -12,3 +12,16 @@ Add this alias to your shell alias file:
 alias console="php bin/console"
 alias phpunits="php bin/phpunit"
 ```
+
+### Code style
+
+To run the excellent [PHP Coding Standards Fixer](https://cs.symfony.com/) tool - `php-cs-fixer` - do:
+
+```sh
+composer run php-lint
+composer run php-cs-fixer
+```
+
+The first command will show linting issues with files; the second will fix them. The former command also runs on PRs via a [Github workflow](vendor/api-platform/schema-generator/.github/workflows/ci.yml)
+
+If you're using VS Code then install the [junstyle.php-cs-fixer](https://marketplace.visualstudio.com/items?itemName=junstyle.php-cs-fixer) plugin. PHPStorm should integrate `php-cs-fixer` out of the box.

--- a/api/README.md
+++ b/api/README.md
@@ -4,6 +4,13 @@ The API will be here.
 
 Refer to the [Getting Started Guide](https://api-platform.com/docs/distribution) for more information. If you'd like to not use Docker (hint: it's a _lot_ more work to do manual setup) then view [SETUP.md](SETUP.md).
 
+This starter template is the standard API Platform code (3.0.0) with some additional helpful things added:
+
+* manual setup documentation
+* disabling Mercure
+* testing documentation
+* php-cs-fixer integration
+
 ## Helpful development things
 
 Add this alias to your shell alias file:

--- a/api/README.md
+++ b/api/README.md
@@ -1,5 +1,14 @@
-# API
+# Quote this Woman API
 
 The API will be here.
 
-Refer to the [Getting Started Guide](https://api-platform.com/docs/distribution) for more information.
+Refer to the [Getting Started Guide](https://api-platform.com/docs/distribution) for more information. If you'd like to not use Docker (hint: it's a _lot_ more work to do manual setup) then view [SETUP.md](SETUP.md).
+
+## Helpful development things
+
+Add this alias to your shell alias file:
+
+```sh
+alias console="php bin/console"
+alias phpunits="php bin/phpunit"
+```

--- a/api/SETUP.md
+++ b/api/SETUP.md
@@ -16,14 +16,14 @@ Link the site with [Valet](https://laravel.com/docs/9.x/valet):
 
 ```sh
 cd public
-valet link api.quotethiswoman
+valet link api.newsite
 valet secure
 valet open
 ```
 
-This will open [https://api.quotethiswoman.test/](https://api.quotethiswoman.test/) in a browser and you should see OpenApi docs.
+This will open [https://api.newsite.test/](https://api.newsite.test/) in a browser and you should see OpenApi docs.
 
-If you don't have Valet then using nginx/apache/whatever you use, create a new site pointing at the `public` folder and make sure it is available at [https://api.quotethiswoman.test/](https://api.quotethiswoman.test/)
+If you don't have Valet then using nginx/apache/whatever you use, create a new site pointing at the `public` folder and make sure it is available at [https://api.newsite.test/](https://api.newsite.test/)
 
 ## Database - postgres
 
@@ -31,8 +31,8 @@ Why postgres? API Platform prefers it over MySQL. MySQL could also be used, but 
 
 1. Install postgres (on a Mac, this is with Homebrew - `brew install pgsql`).
 2. Connect to it with a client - [DBeaver](https://dbeaver.io/) is recommended.
-3. Create a new database, the name could be `quote_this_woman_api_platform`.
-4. Create a new `test` database, the name could be `quote_this_woman_api_platform_test`
+3. Create a new database, the name could be `newsite_api_platform`.
+4. Create a new `test` database, the name could be `newsite_api_platform_test`
 5. Locally on Mac, your system username will be your default user without a password.
 
 ### Database credentials
@@ -44,11 +44,11 @@ cp .env.test .env.test.local
 
 Then, in `.env.local` edit the `DATABASE_URL` connection string. Mine looks like follows:
 
-`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/quote_this_woman_api_platform?serverVersion=14&charset=utf8"`
+`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/newsite_api_platform?serverVersion=14&charset=utf8"`
 
 In `.env.test.local` add the following:
 
-`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/quote_this_woman_api_platform?serverVersion=14&charset=utf8"`
+`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/newsite_api_platform?serverVersion=14&charset=utf8"`
 
 Yes, it looks the same, but Symfony will always append a `_test` to the database name in the test environment.
 

--- a/api/SETUP.md
+++ b/api/SETUP.md
@@ -1,0 +1,75 @@
+# Local setup without Docker
+
+Much easier to use Docker - see [Getting Started Guide](https://api-platform.com/docs/distribution) for how. If you really _want_ to use Valet, PHP, and Postgres (all via HomeBrew), then read on.
+
+## PHP
+
+Ensure you're running php 8.1 (`brew install php`). Then:
+
+```sh
+composer install
+```
+
+## Web server - Valet
+
+Link the site with [Valet](https://laravel.com/docs/9.x/valet):
+
+```sh
+cd public
+valet link api.quotethiswoman
+valet secure
+valet open
+```
+
+This will open [https://api.quotethiswoman.test/](https://api.quotethiswoman.test/) in a browser and you should see OpenApi docs.
+
+If you don't have Valet then using nginx/apache/whatever you use, create a new site pointing at the `public` folder and make sure it is available at [https://api.quotethiswoman.test/](https://api.quotethiswoman.test/)
+
+## Database - postgres
+
+Why postgres? API Platform prefers it over MySQL. MySQL could also be used, but after my (Roger's) experience with both it's much of a muchness. Postgres has a _much_ smaller memory footprint than MySQL (83 MB vs 609MB) so is also nicer for local development.
+
+1. Install postgres (on a Mac, this is with Homebrew - `brew install pgsql`).
+2. Connect to it with a client - [DBeaver](https://dbeaver.io/) is recommended.
+3. Create a new database, the name could be `quote_this_woman_api_platform`.
+4. Create a new `test` database, the name could be `quote_this_woman_api_platform_test`
+5. Locally on Mac, your system username will be your default user without a password.
+
+### Database credentials
+
+```sh
+cp .env .env.local
+cp .env.test .env.test.local
+```
+
+Then, in `.env.local` edit the `DATABASE_URL` connection string. Mine looks like follows:
+
+`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/quote_this_woman_api_platform?serverVersion=14&charset=utf8"`
+
+In `.env.test.local` add the following:
+
+`DATABASE_URL="postgresql://rs:@127.0.0.1:5432/quote_this_woman_api_platform?serverVersion=14&charset=utf8"`
+
+Yes, it looks the same, but Symfony will always append a `_test` to the database name in the test environment.
+
+### Run database migrations
+
+This will test that postgres is running and accessible, and then run database migrations to create tables:
+
+```sh
+php bin/console doctrine:migrations:migrate
+php bin/console doctrine:migrations:migrate --env=test
+```
+
+Then, using DBeaver, take a look at your database and ensure that some tables exist.
+
+## Test setup
+
+Tests can be run with either of the following:
+
+```sh
+php bin/phpunit
+composer run phpunit
+```
+
+If you get the error `sh: composer: command not found` then set the `COMPOSER_BINARY` env var in `.env.test.local` to the full path of the location of your composer bin (i.e. the output of `which composer` - but an absolute path).

--- a/api/TESTS.md
+++ b/api/TESTS.md
@@ -1,0 +1,21 @@
+# Testing
+
+Tests can be run with either of the following:
+
+```sh
+php bin/phpunit
+composer run phpunit
+```
+
+Tests run on the test database.
+
+## Code coverage
+
+To generate tests with code coverage:
+
+```sh
+composer run phpunit
+composer run phpunit-cov
+```
+
+Then open `build/logs/phpunit/html/index.hml` in a browser.

--- a/api/composer.json
+++ b/api/composer.json
@@ -84,7 +84,9 @@
         ],
         "post-update-cmd": [
             "@auto-scripts"
-        ]
+        ],
+        "phpunit": "php bin/phpunit",
+        "phpunit-cov": "php bin/phpunit --coverage-clover build/logs/phpunit/clover.xml --coverage-html build/logs/phpunit/html"
     },
     "conflict": {
         "symfony/symfony": "*"

--- a/api/composer.json
+++ b/api/composer.json
@@ -85,6 +85,8 @@
         "post-update-cmd": [
             "@auto-scripts"
         ],
+        "php-lint": "php-cs-fixer fix --dry-run --diff",
+        "php-cs-fixer": "php-cs-fixer fix -v",
         "phpunit": "php bin/phpunit",
         "phpunit-cov": "php bin/phpunit --coverage-clover build/logs/phpunit/clover.xml --coverage-html build/logs/phpunit/html"
     },

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -9092,5 +9092,5 @@
         "ext-iconv": "*"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.3.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/api/config/packages/api_platform.yaml
+++ b/api/config/packages/api_platform.yaml
@@ -2,7 +2,7 @@ api_platform:
     title: Hello API Platform
     version: 1.0.0
     # Mercure integration, remove if unwanted
-    mercure: ~
+    # mercure: ~
     # Good cache defaults for REST APIs
     defaults:
         stateless: true

--- a/api/docker/caddy/Caddyfile
+++ b/api/docker/caddy/Caddyfile
@@ -3,9 +3,7 @@
     {$DEBUG}
     # HTTP/3 support
     servers {
-        protocol {
-            experimental_http3
-        }
+        protocols h1 h2 h3
     }
 }
 

--- a/api/phpunit.xml.dist
+++ b/api/phpunit.xml.dist
@@ -7,6 +7,7 @@
          colors="true"
          bootstrap="tests/bootstrap.php"
          convertDeprecationsToExceptions="false"
+         stopOnFailure="false"
 >
     <php>
         <ini name="display_errors" value="1" />

--- a/api/src/Entity/Greeting.php
+++ b/api/src/Entity/Greeting.php
@@ -14,7 +14,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 class Greeting
 {
     /**
-     * The entity ID
+     * The entity ID.
      */
     #[ORM\Id]
     #[ORM\Column(type: 'integer')]
@@ -22,7 +22,7 @@ class Greeting
     private ?int $id = null;
 
     /**
-     * A nice person
+     * A nice person.
      */
     #[ORM\Column]
     #[Assert\NotBlank]

--- a/api/src/Entity/Greeting.php
+++ b/api/src/Entity/Greeting.php
@@ -9,7 +9,7 @@ use Symfony\Component\Validator\Constraints as Assert;
 /**
  * This is a dummy entity. Remove it!
  */
-#[ApiResource(mercure: true)]
+#[ApiResource(mercure: false)]
 #[ORM\Entity]
 class Greeting
 {


### PR DESCRIPTION
This starter template is the standard [API Platform](https://api-platform.com/) release [3.0.0](https://github.com/api-platform/api-platform/releases) with some additional helpful things added:

* manual setup documentation
* disabling Mercure
* testing documentation (include code coverage)
* php-cs-fixer integration

The idea is that I can fork this repo as a starter for future projects. Updates will then happen on this repo, and merged in downstream.